### PR TITLE
Add chrome-extension:// and extension:// to restrictedUrls

### DIFF
--- a/background.js
+++ b/background.js
@@ -41,7 +41,10 @@ function generateMarkdownAndTimestamp(tabs, markdownFormat) {
 function shouldProcessTab(tab, restrictedUrls, processOnlySelectedTabs) {
   const isPinned = tab.pinned;
   const isSettingsTab =
-    tab.url.startsWith("edge://") || tab.url.startsWith("chrome://");
+    tab.url.startsWith("edge://") || 
+    tab.url.startsWith("chrome://") || 
+    tab.url.startsWith("chrome-extension://") || 
+    tab.url.startsWith("extension://");
   const isRestrictedUrl = restrictedUrls.some((url) => tab.url.includes(url));
   const isSelected = tab.highlighted;
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "tabSidian",
-  "version": "1.7",
+  "version": "1.7.1",
   "description": "A browser extension to summarize open tabs into Obsidian markdown files.",
   "icons": {
     "48": "icon48.png",

--- a/options.js
+++ b/options.js
@@ -31,7 +31,7 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 function setDefaultRestrictedUrls() {
-  const defaultRestrictedUrls = ["mail.google.com", "outlook.live.com"];
+  const defaultRestrictedUrls = ["chrome-extension://", "extension://", "mail.google.com", "outlook.live.com"];
   document.getElementById("restrictedUrls").value =
     defaultRestrictedUrls.join("\n");
   chrome.storage.sync.set({ restrictedUrls: defaultRestrictedUrls });


### PR DESCRIPTION
Add `chrome-extension://` and `extension://` to the list of restricted URLs.

* Update `background.js` to include `chrome-extension://` and `extension://` in the `isSettingsTab` check within the `shouldProcessTab` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cgranier/tabSidian?shareId=5168057a-3705-4908-a876-cbe3f9ef207a).